### PR TITLE
Remove sanitize from Crate constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class Crate {
    */
   constructor(name, seratoFolder) {
     // TODO: Make private
-    this.name = sanitizeFilename(name);
+    this.name = name;
     this.filename = this.name + ".crate";
     this.songPaths = [];
 


### PR DESCRIPTION
Hey @bcollazo -- this is a fantastic library!  

The sanitize method you're using when creating new Crate objects breaks subcrates, which are formatted with `%%` as an indicator of nesting (e.g. `NOSTALGIA FACTORY%%1950's.crate` where 1950's is nested under NOSTALGIA FACTORY).

I heavily use subcrates and this library was unable to access / manage my subcrates. Curious what issues caused the need for sanitize? Or if it was just a precaution? 

If the latter, removing sanitize provides additional functionality for this library. 

FYI - I'm using your library in a cli util to [programmatically update file paths](https://github.com/lumifylabs/serato-path-update) for my entire library.